### PR TITLE
feat: Added Canvas Preview

### DIFF
--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -1,0 +1,81 @@
+import { useContext, useRef } from "react";
+import { Dialog, DialogContent, IconButton } from "@mui/material";
+import ReactFlow, { ReactFlowProvider, Background, Controls } from "reactflow";
+import CustomDemoNode from './CanvasNode';
+import { CanvasContext } from "../contexts/Canvas";
+import CloseIcon from '@mui/icons-material/Close';
+import RightSidebar   from './RightSidebar';
+
+interface CanvasPreviewProps {
+    workflow: any;  // Array of node objects used in workflow
+    isOpen: boolean;    // Controls if dialog is open
+    onClose: () => void;    // Closes dialog
+}
+
+// Defines node type used in preview. 
+const nodeTypes = {
+    selectorNode: CustomDemoNode,
+};
+
+// This component must be called with an array of nodes for its workflow
+export default function CanvasPreview(props: CanvasPreviewProps) {
+    const { workflow, isOpen, onClose } = props;
+    const reactFlowWrapper = useRef<HTMLDivElement>(null);
+    const { edges } = useContext(CanvasContext);    // We need edges from canvas context as edges aren't passed in via props for simplicity.
+
+    
+    return (
+        <>
+            <Dialog
+                open={isOpen}
+                onClose={onClose}
+                PaperProps={{
+                    style: {
+                        // This width and height affects the overall size of dialog
+                        width: '85vw', 
+                        height: '85vh', 
+                        maxWidth: 'none', 
+                        borderRadius: '12px',
+                    }
+                }}
+            >
+                <IconButton 
+                    onClick={onClose} 
+                    style={{
+                        position: 'absolute', 
+                        top: '8px', 
+                        right: '8px',
+                        zIndex: 10,
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+                <DialogContent style={{ padding: 0, height: '100%', width: '100%', display: 'flex' }}>
+                    {/* Here the react flow and right sidebar have a 70% 30% width split within dialog, with right sidebar having a min width of 500px */}
+                    <ReactFlowProvider>
+                        <div ref={reactFlowWrapper} style={{ width: '70%', height: '100%' }}>
+                            <ReactFlow
+                                nodes={workflow}
+                                edges={edges}
+                                nodeTypes={nodeTypes}
+                                nodesDraggable={false}
+                                nodesConnectable={false}
+                                fitView
+                                fitViewOptions={{padding: 0.2,}}
+                                style={{ width: '100%', height: '100%' }}
+                            >
+                                <Background gap={16} size={1} />
+
+                                <Controls />
+                            </ReactFlow>
+                        </div>
+                    </ReactFlowProvider>
+                  
+                    <div style={{width: '30%', minWidth:'500px'}}>
+                        <RightSidebar noMouseEvents/>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/src/components/ExamplePreviewUsage.tsx
+++ b/src/components/ExamplePreviewUsage.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { useContext } from "react";
+import { CanvasContext } from "../contexts/Canvas";
+import { getWorkflowsFromGraph } from "../controllers/GraphHelpers";
+import CanvasPreview from "./CanvasPreview";
+
+// TODO: Remove this component when done developing canvas preview.
+// This is a simple test component to see how canvas preview is called and used.
+export default function ExamplePreviewUsage()  {
+	// There needs to be two states to control canvas preview, an isOpen to control if it is open, and a state to store the current selected workflow.
+	const [workflow, setWorkFlow] = useState<Node[]>([]); 
+	const [isOpen, setIsOpen] = useState(false);
+
+	// We need canvas context so we can call getWorkflowsFromGraph.
+	const { nodes, edges } = useContext(CanvasContext);
+
+	const openPreview = (index: number) => {
+		const workflows = getWorkflowsFromGraph(nodes, edges);
+        setWorkFlow(workflows[index]);
+		setIsOpen(true);
+	}
+
+	const closePreview = () => {
+		setIsOpen(false);
+	}
+
+	return(
+		<>
+			<div onClick={() => openPreview(0)}>Workflow 1</div>
+			<div onClick={() => openPreview(1)}>Workflow 2</div>
+			<div onClick={() => openPreview(2)}>Workflow 3</div>
+			<CanvasPreview workflow={workflow} isOpen={isOpen} onClose={closePreview}/>
+		</>
+	)
+}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -7,6 +7,7 @@ import { CanvasContext } from '../contexts/Canvas';
 import LoadCanvasButton from './LoadCanvasButton';
 import SaveCanvasButton from './SaveCanvasButton';
 import "../styles/resubmit.css";
+import { useLocation } from 'react-router-dom';
 
 export default function HeaderBar() {
     const navigate = useNavigate();
@@ -16,6 +17,7 @@ export default function HeaderBar() {
     const [snackbarMessage, setSnackbarMessage] = useState("");
 
     const { setNodes, setEdges, nodes, edges } = useContext(CanvasContext);
+    const windowLocation = useLocation();
 
     // This function is responsible for keeping currentCanvas up to date, it is called when user saves or loads a canvas.
     const updateCurrentCanvas = (canvasName = "") => {
@@ -38,6 +40,11 @@ export default function HeaderBar() {
     }
 
     const areChangesUnsaved = useCallback(() => {
+        // This function only returns changes found on the canvas page. If the user is anywhere else return false.
+        if (windowLocation.pathname !== "/canvas") {
+            return false;
+        }
+
         // Get the name of current work from local storage, or the default value if it's empty
         let currentCanvas = localStorage.getItem("CurrentCanvas") || "canvas:";
 
@@ -57,8 +64,8 @@ export default function HeaderBar() {
             // Case 4: If we are here, this means a canvas has been loaded - but no changes made.
             return false;
         }
-    }, [edges, nodes])
-    
+    }, [edges, nodes, windowLocation])
+
     const loadCanvasData = useCallback((canvasName = "canvas:") => {
         // Update currentCanvas to new canvas
         updateCurrentCanvas(canvasName)

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -15,8 +15,12 @@ import { useUtility } from '../contexts/UtilityContext';
 import { RecState } from '../types/Types';
 import '../App.css';
 
+interface SidebarProps {
+    noMouseEvents?: boolean;
+}
 
-export default function ContextTestComponent() {
+export default function ContextTestComponent(props: SidebarProps) {
+    const {noMouseEvents} = props;
 
     const api_url = process.env.REACT_APP_MPI_API || '';
     
@@ -109,157 +113,159 @@ export default function ContextTestComponent() {
     );
 
     return (
-        <div style={{ wordWrap: 'break-word', paddingLeft: 20, paddingRight: 20, overflow: 'scroll', height: '80vh', textAlign: 'left', }}>
-            <div>
+        <div style={{ wordWrap: 'break-word', paddingLeft: 20, paddingRight: 20, overflow: 'scroll', height: '80vh', textAlign: 'left' }}>
+            <div style={{pointerEvents: noMouseEvents ? 'none' : 'auto'}}>
+                <div>
+                    {
+                        hazards.includes(activeNode?.data.label) 
+                        ? (<p><GppMaybe style={{color: "grey", verticalAlign:"bottom"}}/>&nbsp;Note: For this service, 
+                        sequences provided below or produced by the process will undergo a safety screening.</p>)
+                        : ""
+                    }
+                    <h2>
+                        {activeNode?.data.label}
+                    </h2>
+                </div>
+                <div>
+                    {
+                        activeNode?.data.description 
+                        ? <p>{activeNode?.data.description}</p>
+                        : null
+                    }
+                </div>
                 {
-                    hazards.includes(activeNode?.data.label) 
-                    ? (<p><GppMaybe style={{color: "grey", verticalAlign:"bottom"}}/>&nbsp;Note: For this service, 
-                       sequences provided below or produced by the process will undergo a safety screening.</p>)
-                    : ""
-                }
-                <h2>
-                    {activeNode?.data.label}
-                </h2>
-            </div>
-            <div>
-                {
-                    activeNode?.data.description 
-                    ? <p>{activeNode?.data.description}</p>
+                    activeNode?.data.formData 
+                    ? <div><Params activeNode={activeNode}/></div>
                     : null
                 }
-            </div>
-            {
-                activeNode?.data.formData 
-                ? <div><Params activeNode={activeNode}/></div>
-                : null
-            }
-                       <br />
-            <Box hidden={activeNode?.data.label === 'Next Generation Sequencing' ? false : true}>
-                <b>Sample/Pool Info</b> <br />
-                <div>{textArray.map((field: any, index: number) => {
-                        // console.log('active node label: ', activeNode?.data.label)
-                        if (activeNode?.data.label === 'Next Generation Sequencing') {
-                            return(
-                                <div style={{ margin: 20 }}>
-                                    <label>
-                                        {field} &nbsp;
-                                        <input type = "text" value = {fieldArray[index]} style={{marginTop: 5}}
-                                                onChange = {(e) => setterArray[index](e.target.value)} />
-                                    </label>
-                                </div>
-                            )
-                        } else {
-                            return null;
-                        }
-                })}</div>
-                <Box sx={ { flexDirection:'column', textAlign: 'left' } }>
-                    <input name = "id" onChange = { e => { console.log(e.target.value); setID(e.target.value); }} />
-                    <Button onClick = {() => { ID ? get() : console.log('No ID set...') }}>Retrieve Record</ Button>
+                        <br />
+                <Box hidden={activeNode?.data.label === 'Next Generation Sequencing' ? false : true}>
+                    <b>Sample/Pool Info</b> <br />
+                    <div>{textArray.map((field: any, index: number) => {
+                            // console.log('active node label: ', activeNode?.data.label)
+                            if (activeNode?.data.label === 'Next Generation Sequencing') {
+                                return(
+                                    <div style={{ margin: 20 }}>
+                                        <label>
+                                            {field} &nbsp;
+                                            <input type = "text" value = {fieldArray[index]} style={{marginTop: 5}}
+                                                    onChange = {(e) => setterArray[index](e.target.value)} />
+                                        </label>
+                                    </div>
+                                )
+                            } else {
+                                return null;
+                            }
+                    })}</div>
+                    <Box sx={ { flexDirection:'column', textAlign: 'left' } }>
+                        <input name = "id" onChange = { e => { console.log(e.target.value); setID(e.target.value); }} />
+                        <Button onClick = {() => { ID ? get() : console.log('No ID set...') }}>Retrieve Record</ Button>
+                    </Box>
+                    <div style = {{ textAlign: "left", fontSize: 16, width: 100, margin: 5, minHeight: 100 }}>
+                        <pre className={"data"}>ID: {record?record.id:''}</pre>
+                        <pre className={"data"}>Name: {trunc(record?.sequence?.name ?? '')}</pre>
+                        <pre className={"data"}>Type: {trunc(record?.sequence?.type ?? '')}</pre>
+                        <pre className={"data"}>Sequence: {trunc(record?.sequence?.seq ?? '')}</pre>
+                        <pre className={"data"}>Annotations: {trunc(JSON.stringify(record?.sequence?.annotations ?? ''))}</pre>
+                    </div>
+                    <b>Library Info</b> <br /><br />
+                    <div style={{marginLeft: 20}}>
+                        <label>Pool Name: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>Library Name: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>i7 Index Seq: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>i5 Index Seq: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>Custom Read 1: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>Custom Read 2: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>Custom Index 1: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label><br />
+                        <label>Custom Index 2: <br />
+                            <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
+                        </label>
+                    </div>
+                    <Button onClick = {() => { }} sx = {{ ml: 2 }}>+ Add Library</ Button>
+                    <br />
+                    <Button variant='contained' onClick = {() => { put() }} sx = {{ ml: 2 }}>Send to MPI Record {ID}</ Button>
                 </Box>
-                <div style = {{ textAlign: "left", fontSize: 16, width: 100, margin: 5, minHeight: 100 }}>
-                    <pre className={"data"}>ID: {record?record.id:''}</pre>
-                    <pre className={"data"}>Name: {trunc(record?.sequence?.name ?? '')}</pre>
-                    <pre className={"data"}>Type: {trunc(record?.sequence?.type ?? '')}</pre>
-                    <pre className={"data"}>Sequence: {trunc(record?.sequence?.seq ?? '')}</pre>
-                    <pre className={"data"}>Annotations: {trunc(JSON.stringify(record?.sequence?.annotations ?? ''))}</pre>
+                <div>
+                    {
+                        // return header with text Allowed Connections if allowedConnections list is not empty
+                        activeNode && activeNode.data.allowedConnections && activeNode.data.allowedConnections.length > 0 
+                        ? <h3>Allowed Connections</h3>
+                        : null
+                    }
+                    {
+                        activeNode 
+                        && activeNode.data.allowedConnections 
+                        && activeNode.data.allowedConnections.length > 0 
+                        ? (activeNode.data.allowedConnections.map((connection: any) => {
+                            return (
+                                <NodeButton 
+                                    key                  = {Math.random().toString(36).substring(2, 9)}
+                                    node                 = {getServiceFromId(services, connection.id)}
+                                    sourceId             = {val.activeComponentId}
+                                    setNodes             = {val.setNodes}
+                                    setEdges             = {val.setEdges}
+                                    sourcePosition       = {activeNode.position}
+                                    setActiveComponentId = {val.setActiveComponentId}
+                                />
+                            )
+                        })) 
+                        : null
+                    }
                 </div>
-                <b>Library Info</b> <br /><br />
-                <div style={{marginLeft: 20}}>
-                    <label>Pool Name: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>Library Name: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>i7 Index Seq: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>i5 Index Seq: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>Custom Read 1: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>Custom Read 2: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>Custom Index 1: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label><br />
-                    <label>Custom Index 2: <br />
-                        <input type = "text" onChange = {(e) => {}} style={{marginTop: 5}}/>
-                    </label>
+                <div>
+                    {
+                        activeNode 
+                        ? (
+                            <>
+                                <Snackbar
+                                    open             = {openToast}
+                                    autoHideDuration = {3000}
+                                    onClose          = {handleCloseToast}
+                                    message          = "Parameters Saved"
+                                    action           = {action}
+                                    key              = {'bottomright'}
+                                    anchorOrigin     = {{ vertical: 'bottom', horizontal: 'right' }}
+                                />
+                                <Dialog
+                                    open             = {open}
+                                    onClose          = {handleClose}
+                                    aria-labelledby  = "alert-dialog-title"
+                                    aria-describedby = "alert-dialog-description"
+                                >
+                                    <DialogContent>
+                                        <DialogContentText id="alert-dialog-description">
+                                            There are unsaved changes. Do you want to save them?
+                                        </DialogContentText>
+                                    </DialogContent>
+                                    <DialogActions>
+                                        <Button onClick={handleClose}>Discard</Button>
+                                        <Button onClick={handleSave} autoFocus>
+                                            Save
+                                        </Button>
+                                    </DialogActions>
+                                </Dialog>
+                            </>
+                        ) 
+                        : <div><br />Drag a node from the left to the canvas to see its properties here.</div>
+                    }
                 </div>
-                <Button onClick = {() => { }} sx = {{ ml: 2 }}>+ Add Library</ Button>
-                <br />
-                <Button variant='contained' onClick = {() => { put() }} sx = {{ ml: 2 }}>Send to MPI Record {ID}</ Button>
-            </Box>
-            <div>
-                {
-                    // return header with text Allowed Connections if allowedConnections list is not empty
-                    activeNode && activeNode.data.allowedConnections && activeNode.data.allowedConnections.length > 0 
-                    ? <h3>Allowed Connections</h3>
-                    : null
-                }
-                {
-                    activeNode 
-                    && activeNode.data.allowedConnections 
-                    && activeNode.data.allowedConnections.length > 0 
-                    ? (activeNode.data.allowedConnections.map((connection: any) => {
-                        return (
-                            <NodeButton 
-                                key                  = {Math.random().toString(36).substring(2, 9)}
-                                node                 = {getServiceFromId(services, connection.id)}
-                                sourceId             = {val.activeComponentId}
-                                setNodes             = {val.setNodes}
-                                setEdges             = {val.setEdges}
-                                sourcePosition       = {activeNode.position}
-                                setActiveComponentId = {val.setActiveComponentId}
-                            />
-                        )
-                    })) 
-                    : null
-                }
-            </div>
-            <div>
-                {
-                    activeNode 
-                    ? (
-                        <>
-                            <Snackbar
-                                open             = {openToast}
-                                autoHideDuration = {3000}
-                                onClose          = {handleCloseToast}
-                                message          = "Parameters Saved"
-                                action           = {action}
-                                key              = {'bottomright'}
-                                anchorOrigin     = {{ vertical: 'bottom', horizontal: 'right' }}
-                            />
-                            <Dialog
-                                open             = {open}
-                                onClose          = {handleClose}
-                                aria-labelledby  = "alert-dialog-title"
-                                aria-describedby = "alert-dialog-description"
-                            >
-                                <DialogContent>
-                                    <DialogContentText id="alert-dialog-description">
-                                        There are unsaved changes. Do you want to save them?
-                                    </DialogContentText>
-                                </DialogContent>
-                                <DialogActions>
-                                    <Button onClick={handleClose}>Discard</Button>
-                                    <Button onClick={handleSave} autoFocus>
-                                        Save
-                                    </Button>
-                                </DialogActions>
-                            </Dialog>
-                        </>
-                    ) 
-                    : <div><br />Drag a node from the left to the canvas to see its properties here.</div>
-                }
-            </div>
-            <div>
-                {/* <Button onClick={ ()=> console.log(JSON.stringify(val.nodes), JSON.stringify(val.edges))}><br/>Print</Button> */}
+                <div>
+                    {/* <Button onClick={ ()=> console.log(JSON.stringify(val.nodes), JSON.stringify(val.edges))}><br/>Print</Button> */}
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
**What was added?**
- Added a canvas preview component that shows the user a read-only view of a specific workflow
- The component works as an MUI Dialog that needs 3 inputs
- isOpen - Controls if dialog is open
- workflow - an array of nodes to display
- onClose - function that is called when user clicks away from the dialog or clicks the close button in top right
- I also added an ExamplePreviewUsage component to see how I intended it to be used. This is intended to be deleted once this preview is integrated with Bardan's checkout pages

**What was changed?**
- Fixed a bug the following bug:
- I discovered a bug that my unsaved changes warning was going off in unintended places
- In headerbar.tsx, I implemented a fix so the warning will only fire if the user is leaving the /canvas page
- I also added an optional prop to RightSidebar that makes it read-only.

**Other Notes**
- Canvas preview cannot be called whenever there is another canvas currently being rendered. 
- For example, if you try to render canvas preview while on the main /canvas page, it won't display as expected
- This shouldn't cause any issues as we should never need to call this component when there is already a canvas the user can interact with on screen