### PR TITLE
Bundles Tab of Admin Edit Page

### DIFF
--- a/src/components/edit/BundleCanvasPopup.tsx
+++ b/src/components/edit/BundleCanvasPopup.tsx
@@ -1,0 +1,295 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogActions, 
+  DialogTitle,
+  Button, 
+  Typography,
+  Box,
+  Chip
+} from '@mui/material';
+import ReactFlow, {
+  ReactFlowProvider,
+  addEdge,
+  applyNodeChanges,
+  applyEdgeChanges,
+  NodeChange,
+  EdgeChange,
+  Connection,
+  Background,
+  Controls,
+  useReactFlow,
+  Node
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { NodeData } from '../../types/CanvasTypes';
+import { createNodeObject } from '../../controllers/ReactFlowEvents';
+
+type BundleCanvasPopupProps = {
+  open: boolean;
+  onClose: () => void;
+  bundle: {
+    id: string;
+    label: string;
+    services: any[];
+  } | null;
+  allServices: any[];
+  onSave: (updatedServices: any[]) => void;
+};
+
+const BundleCanvasContent: React.FC<{
+  bundle: NonNullable<BundleCanvasPopupProps['bundle']>;
+  allServices: any[];
+  onSave: (services: any[]) => void;
+  onClose: () => void;
+}> = ({ bundle, allServices, onSave, onClose }) => {
+  const [nodes, setNodes] = useState<Node<NodeData>[]>([]);
+  const [edges, setEdges] = useState<any[]>([]);
+  const [hasChanges, setHasChanges] = useState(false); // Implement this feat in case admin closes before saving
+  const { fitView } = useReactFlow();
+
+
+  useEffect(() => {
+    if (bundle && bundle.services) {
+      const initialNodes = bundle.services.map((service, index) => {
+        // Grid layout like the MainFLow Canvas
+        const cols = 4;
+        const nodeSpacing = { x: 200, y: 150 };
+        const position = { 
+          x: (index % cols) * nodeSpacing.x + 50, 
+          y: Math.floor(index / cols) * nodeSpacing.y + 50 
+        };
+        
+        const nodeId = service.id || `service-${index}`;
+        const data: NodeData = {
+          id: nodeId,
+          label: service.name || service.label || 'Unnamed Service',
+          serviceId: service.id,
+          icon: service.icon,
+          price: service.price,
+          description: service.description,
+          parameters: service.parameters || [],
+          allowedConnections: service.allowedConnections || [],
+          formData: [],
+          paramGroups: service.paramGroups || [],
+          additionalInstructions: '',
+        };
+        
+        return createNodeObject(nodeId, data.label, 'selectorNode', position, data);
+      });
+      setNodes(initialNodes);
+      setEdges([]);
+      setHasChanges(false);
+      
+      setTimeout(() => fitView({ padding: 0.1 }), 100); // Fit view after nodes are rendered
+    }
+    }, [bundle, fitView]);
+
+    const onNodesChange = useCallback((changes: NodeChange[]) => {
+        setNodes((nds) => applyNodeChanges(changes, nds));
+        setHasChanges(true);
+    }, []);
+
+    const onEdgesChange = useCallback((changes: EdgeChange[]) => {
+        setEdges((eds) => applyEdgeChanges(changes, eds));
+        setHasChanges(true);
+    }, []);
+
+    const onConnect = useCallback((connection: Connection) => {
+        setEdges((eds) => addEdge(connection, eds));
+        setHasChanges(true);
+    }, []);
+
+
+    const addServiceToCanvas = (service: any) => {
+        const existingNode = nodes.find(node => node.data.serviceId === service.id);
+        if (existingNode) return;
+
+        const newNodeId = `service-${service.id}-${Date.now()}`; // Random spawn pos so services aren't on top of each other
+        const position = { 
+            x: Math.random() * 300 + 50, 
+            y: Math.random() * 200 + 50 
+        };
+
+        const data: NodeData = {
+            id: newNodeId,
+            label: service.name || service.label || 'Unnamed Service',
+            serviceId: service.id,
+            icon: service.icon,
+            price: service.price,
+            description: service.description,
+            parameters: service.parameters || [],
+            allowedConnections: service.allowedConnections || [],
+            formData: [],
+            paramGroups: service.paramGroups || [],
+            additionalInstructions: '',
+        };
+
+        const newNode = createNodeObject(newNodeId, data.label, 'selectorNode', position, data);
+        setNodes((nds) => [...nds, newNode]);
+        setHasChanges(true);
+  };
+
+
+  const removeServiceFromCanvas = (serviceId: string) => {
+    setNodes((nds) => nds.filter(node => node.data.serviceId !== serviceId));
+    setEdges((eds) => eds.filter(edge => 
+      !nodes.some(node => node.data.serviceId === serviceId && (edge.source === node.id || edge.target === node.id))
+    ));
+    setHasChanges(true);
+  };
+
+  const handleSave = () => {
+    const updatedServices = nodes.map((node) => {
+      // look up original service to keep fields not editable on Canvas
+      // Edge case: if allServices has no services, originalService = {}, only keep fields set
+      const originalService = allServices.find(s => s.id === node.data.serviceId) || {};
+      
+      return {
+        ...originalService,
+        id: node.data.serviceId,
+        name: node.data.label,
+        icon: node.data.icon,
+        price: node.data.price,
+        description: node.data.description,
+        parameters: node.data.parameters,
+        allowedConnections: node.data.allowedConnections,
+        paramGroups: node.data.paramGroups,
+      };
+    });
+    
+    onSave(updatedServices);
+  };
+
+  const handleClose = () => {
+    if (hasChanges) {
+      if (window.confirm('You have unsaved changes. Are you sure you want to close?')) {
+        onClose();
+      }
+    } else {
+      onClose();
+    }
+  };
+
+  // First find which services are alr on Canvas, then filter to only display unused services
+  // Only problem currently is after you add a service, you can't find it in Available again... also UI sucks
+  const availableServices = allServices.filter(service => 
+    !nodes.some(node => node.data.serviceId === service.id)
+  );
+
+  return (
+    <>
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">
+            Edit Bundle: {bundle.label}
+          </Typography>
+        </Box>
+      </DialogTitle>
+      
+      <DialogContent sx={{ height: '70vh', display: 'flex', flexDirection: 'column', p: 0 }}>
+        {/* Available Services Panel */}
+        {availableServices.length > 0 && (
+          <Box sx={{ p: 2, borderBottom: '1px solid #e0e0e0', bgcolor: '#f5f5f5' }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Available Services:
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {availableServices.slice(0, 10).map((service) => (
+                <Chip
+                  key={service.id}
+                  label={service.name || service.label}
+                  onClick={() => addServiceToCanvas(service)}
+                  size="small"
+                  variant="outlined"
+                  sx={{ cursor: 'pointer' }}
+                />
+              ))}
+              {availableServices.length > 10 && (
+                <Typography variant="caption" color="text.secondary">
+                  +{availableServices.length - 10} more...
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        )}
+
+        {/* Canvas */}
+        <Box sx={{ flex: 1, position: 'relative' }}>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            fitView
+            style={{ width: '100%', height: '100%' }}
+            minZoom={0.1}
+            maxZoom={2}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background />
+            <Controls />
+          </ReactFlow>
+        </Box>
+
+        {/* Current Services List */}
+        {nodes.length > 0 && (
+          <Box sx={{ p: 2, borderTop: '1px solid #e0e0e0', bgcolor: '#f9f9f9' }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Services in Bundle: {nodes.length}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {nodes.map((node) => (
+                <Chip
+                  key={node.id}
+                  label={node.data.label}
+                  onDelete={() => removeServiceFromCanvas(node.data.serviceId)}
+                  size="small"
+                  color="primary"
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+      </DialogContent>
+      
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={handleClose} color="secondary">
+          Cancel
+        </Button>
+        <Button 
+          onClick={handleSave} 
+          variant="contained"
+          disabled={nodes.length === 0}
+        >
+          Save Bundle
+        </Button>
+      </DialogActions>
+    </>
+  );
+};
+
+
+export const BundleCanvasPopup: React.FC<BundleCanvasPopupProps> = ({open, onClose, bundle, allServices, onSave}) => {
+  if (!bundle) return null;
+
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose} 
+      fullWidth 
+      maxWidth="xl"
+    >
+      <ReactFlowProvider>
+        <BundleCanvasContent
+          bundle={bundle}
+          allServices={allServices}
+          onSave={onSave}
+          onClose={onClose}
+        />
+      </ReactFlowProvider>
+    </Dialog>
+  );
+};

--- a/src/components/edit/EditBundlesTable.tsx
+++ b/src/components/edit/EditBundlesTable.tsx
@@ -1,11 +1,111 @@
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { useContext } from 'react';
+import { useApolloClient } from '@apollo/client';
+import { DELETE_BUNDLE, CREATE_BUNDLE, UPDATE_BUNDLE } from '../../gql/mutations';
+import {
+  DataGrid,
+  GridColDef,
+  GridRowModesModel,
+  GridRowModes,
+  GridRowId,
+  GridRowModel,
+  GridEventListener,
+  GridRowEditStopReasons,
+  GridRenderCellParams,
+  GridRenderEditCellParams,
+  useGridApiRef
+} from '@mui/x-data-grid';
+import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/App';
-import { ServiceSelection } from './ServiceSelection';
+import { getActionsColumn } from './ActionColumn';
 import { ServiceList } from './ServiceList';
+import { ServiceSelection } from './ServiceSelection';
+import { Button, Snackbar, Alert } from '@mui/material';
+import { GridToolBar } from './GridToolBar';
+
+type BundleRow = GridRowModel & {
+  error?: string;
+  isNew?: boolean;
+};
 
 export const EditBundlesTable: React.FC = () => {
   const { bundles, services } = useContext(AppContext);
+  const [rows, setRows] = useState<BundleRow[]>([]);
+  const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+  const client = useApolloClient();
+  const gridRef = useGridApiRef();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRows(bundles);
+  }, [bundles]);
+
+  // DELETE
+  const handleDeletion = async (id: GridRowId) => {
+    try {
+      await client.mutate({
+        mutation: DELETE_BUNDLE,
+        variables: { id }
+      });
+      setRows(rows.filter((row) => row.id !== id));
+    } catch (err) {
+      console.error('Error deleting bundle:', err);
+      setErrorMessage('Failed to delete bundle');
+    }
+  };
+
+  // UPDATE
+  const handleUpdate = async (newRow: GridRowModel) => {
+    const changes = {
+      label: newRow.label,
+      icon: newRow.icon || null,
+      services: newRow.services?.map((s: any) => s.id) || []
+    };
+
+    await client.mutate({
+      mutation: UPDATE_BUNDLE,
+      variables: {
+        bundle: newRow.id,
+        changes
+      }
+    });
+
+    return newRow;
+  };
+
+  // CREATE
+  const handleCreate = async (newRow: GridRowModel) => {
+    const input = {
+      label: newRow.label || '',
+      icon: newRow.icon || null,
+      services: newRow.services?.map((s: any) => s.id) || []
+    };
+
+    const result = await client.mutate({
+      mutation: CREATE_BUNDLE,
+      variables: { input }
+    });
+
+    setRows((prev) =>
+      prev.map((row) =>
+        row.id === newRow.id ? { ...result.data.createBundle, isNew: false } : row
+      )
+    );
+
+    return { ...result.data.createBundle, isNew: false };
+  };
+
+  const processRowUpdate = async (newRow: BundleRow) => {
+    if (!newRow.isNew) {
+      return handleUpdate(newRow);
+    } else {
+      return handleCreate(newRow);
+    }
+  };
+
+  const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
+    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+      event.defaultMuiPrevented = true;
+    }
+  };
 
   const columns: GridColDef[] = [
     {
@@ -13,19 +113,58 @@ export const EditBundlesTable: React.FC = () => {
       width: 500,
       editable: true
     },
-    {
+    { // Potentially change UI so services are easier to see in some kind of pop up
       field: 'services',
       headerName: 'Services',
       width: 500,
       renderCell: (params) => <ServiceList services={params.row.services} />,
-      renderEditCell: (params) => <ServiceSelection allServices={services} selectedServices={params.row.services} />
-    }
+      renderEditCell: (params: GridRenderEditCellParams) => (
+        <ServiceSelection allServices={services} selectedServices={params.row.services} {...params} />
+      )
+    },
+    getActionsColumn({
+      handleDelete: handleDeletion,
+      handleEdit: (id) =>
+        setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } }),
+      handleCancel: (id) =>
+        setRowModesModel({
+          ...rowModesModel,
+          [id]: { mode: GridRowModes.View, ignoreModifications: true }
+        }),
+      handleSave: (id) =>
+        setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } }),
+      rowModesModel
+    })
   ];
 
   return (
-    <DataGrid
-      rows={bundles}
-      columns={columns}
-    />
+    <>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        rowModesModel={rowModesModel}
+        onRowModesModelChange={(newModel) => setRowModesModel(newModel)}
+        onRowEditStop={handleRowEditStop}
+        processRowUpdate={processRowUpdate}
+        editMode="row"
+        slots={{
+          toolbar: GridToolBar as any
+        }}
+        slotProps={{
+          toolbar: { setRowModesModel, setRows }
+        }}
+        apiRef={gridRef}
+      />
+      <Snackbar
+        open={!!errorMessage}
+        autoHideDuration={4000}
+        onClose={() => setErrorMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setErrorMessage(null)} severity="error" sx={{ width: '100%' }}>
+          {errorMessage}
+        </Alert>
+      </Snackbar>
+    </>
   );
 };

--- a/src/gql/mutations.tsx
+++ b/src/gql/mutations.tsx
@@ -84,9 +84,22 @@ export const UPDATE_ANNOUNCEMENT = gql`
   }
 `;
 
+export const UPDATE_BUNDLE = gql `
+  mutation UpdateBundle($bundle: ID!, $changes: BundleChange!) {
+    updateBundle(bundle: $bundle, changes: $changes){
+        id
+        label
+        icon
+        services{
+            id
+            name}
+    } 
+  }
+`
+
 export const CREATE_BUNDLE = gql `
   mutation CreateBundle($input: CreateBundleInput!) {
-    createbundle(input: $input) {
+    createBundle(input: $input) {
         id
         label
         icon

--- a/src/gql/mutations.tsx
+++ b/src/gql/mutations.tsx
@@ -83,3 +83,23 @@ export const UPDATE_ANNOUNCEMENT = gql`
     }
   }
 `;
+
+export const CREATE_BUNDLE = gql `
+  mutation CreateBundle($input: CreateBundleInput!) {
+    createbundle(input: $input) {
+        id
+        label
+        icon
+        services {
+            id
+            name
+        }
+    }
+  }
+`;
+
+export const DELETE_BUNDLE = gql `
+  mutation DeleteBundle($id: ID!) {
+    deleteBundle(id: $id)
+  }
+`;


### PR DESCRIPTION
## Description

> This PR adds new features in the Bundle tab table so that admins can now create, update, and delete bundles in the database. 

## Changes:

**EditBundlesTable.tsx**
- Integrates Create, Update, Delete actions from the actions column
- Calls gql mutations directly to the backend
- Incorporates a mini canvas for admins to visually connect services to create their desired bundle

**BundleCanvasPopup.tsx**
- Component that mirrors the functionality of MainFlow.tsx canvas to use the services to create a template workflow
- Available services section: finds which services are already on Canvas, then filters them to only display unused services
- Future revamps will need to improve the UI here as this component coupled with the Services in Bundle clutter the mini canvas page. Perhaps a search icon instead, with a dropdown of the services searched.

