### PR TITLE
Refresh access token, replace token with getter fn in context

### DIFF
--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -44,7 +44,11 @@ async function getAccessToken() : Promise<string | undefined> {
 }
 
 
-async function initKeycloak(): Promise<UserProps> {
+async function initKeycloak(): Promise<UserProps | null> {
+  // Do not attempt to initialize during SSR
+  if (typeof window === 'undefined') {
+    return null;
+  }
   try {
     await keycloak.init({
       onLoad: "check-sso",


### PR DESCRIPTION
The access token issued by Keycloak is short-lived (5 minutes). Replace the accessToken in the User Context with a getter function which refreshes the access token when necessary. 

Also add a check in initKeycloak to prevent it running during SSR - see discussion at https://github.com/hicsail/damplab-ui/pull/50#issuecomment-3214410458.